### PR TITLE
remove deprecated no_nl2br option for github extension

### DIFF
--- a/raphidoc/generator.py
+++ b/raphidoc/generator.py
@@ -60,7 +60,7 @@ class Generator:
                                                 'markdown.extensions.def_list',
                                                 'markdown.extensions.codehilite',
                                                 'markdown.extensions.admonition',
-                                                'pymdownx.github(no_nl2br=True)'])
+                                                'pymdownx.github'])
 
         self._setup_output()
         self._copy_assets()


### PR DESCRIPTION
The option `no_nl2br` has been deprecated and removed from the [Github Markdown Extension](https://github.com/facelessuser/pymdown-extensions). See https://github.com/facelessuser/pymdown-extensions/issues/24

> github extension now turns off nl2br by default in order properly emulate recent changes in GFM. no_nl2br option is deprecated and will be removed in the future as it no longer reflects GFM behavior.

[(from pymdown-extensions changelog)](https://github.com/facelessuser/pymdown-extensions/blob/152e85baa10616054535f4bfeb99345d87741655/docs/src/markdown/changelog.md#130)