### PR TITLE
fix breaking change from mathjax-node v1.0

### DIFF
--- a/raphidoc/mdx_math.py
+++ b/raphidoc/mdx_math.py
@@ -112,7 +112,7 @@ def compile_latex(formula, inline, cache_directory, no_cache=False, after_error=
                 return f.read()
     try:
         logger.debug('Rendering formula {}'.format(formula))
-        program = """var mjAPI = require("mathjax-node/lib/mj-single.js");
+        program = """var mjAPI = require("mathjax-node");
         mjAPI.typeset({
           math: %s,
           format: "%s", // "TeX", "inline-TeX", "MathML"


### PR DESCRIPTION
From [MathJax-node v1.0.0 Release Notes:](https://github.com/mathjax/MathJax-node/releases/tag/1.0.0)

> `mj-single.js` has been renamed to `main.js` and can be accessed with `\require('mathjax-node')`.

